### PR TITLE
Expose response XML, and add ReportType constants

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ It also accepts a configuration block to streamline gets.
 VinQuery.configure do |config|
   config.url = 'vinquery-url-here'
   config.access_code = 'access-code-here'
-  config.report_type = 2
+  config.report_type = VinQuery::ReportType::EXTENDED
 end
 
 query = VinQuery.get('1C3CC4FB8AN236750')

--- a/lib/vin_query/configuration.rb
+++ b/lib/vin_query/configuration.rb
@@ -1,4 +1,11 @@
 module VinQuery
+  module ReportType
+    BASIC = 0
+    STANDARD = 1
+    EXTENDED = 2
+    LITE = 3
+  end
+
   class << self
     attr_accessor :configuration
   end
@@ -16,7 +23,7 @@ module VinQuery
     attr_accessor :url, :access_code, :report_type
 
     def initialize
-      @report_type = 2
+      @report_type = ReportType::EXTENDED
     end
 
     def merge_options(options={})

--- a/lib/vin_query/configuration.rb
+++ b/lib/vin_query/configuration.rb
@@ -8,10 +8,13 @@ module VinQuery
 
   class << self
     attr_accessor :configuration
+
+    def configuration
+      @configuration ||= Configuration.new
+    end
   end
 
   def self.configure
-    self.configuration ||= Configuration.new
     yield(configuration)
   end
 

--- a/lib/vin_query/query.rb
+++ b/lib/vin_query/query.rb
@@ -3,7 +3,7 @@ require 'nokogiri'
 
 module VinQuery
   class Query
-    attr_reader :vin, :url, :trim_levels
+    attr_reader :vin, :url, :response_xml, :trim_levels
 
     def initialize(vin, options={})
       VinQuery.configuration.merge_options(options)
@@ -57,8 +57,8 @@ module VinQuery
     end
 
     def get
-      xml = fetch(@url)
-      parse(xml) if validate(xml)
+      @response_xml = fetch(@url)
+      parse(@response_xml) if validate(@response_xml)
     end
 
     private

--- a/spec/lib/vin_query/configuration_spec.rb
+++ b/spec/lib/vin_query/configuration_spec.rb
@@ -14,13 +14,13 @@ describe VinQuery::Configuration do
   end
 
   it 'has a default report type' do
-    expect(VinQuery.configuration.report_type).to eq 2
+    expect(VinQuery.configuration.report_type).to eq VinQuery::ReportType::EXTENDED
   end
 
   context 'when manually given options' do
     it 'overrides default configuration settings' do
-      VinQuery.configuration.merge_options(report_type: 3)
-      expect(VinQuery.configuration.report_type).to eq 3
+      VinQuery.configuration.merge_options(report_type: VinQuery::ReportType::LITE)
+      expect(VinQuery.configuration.report_type).to eq VinQuery::ReportType::LITE
     end
 
     it 'overrides previously set configuration settings' do

--- a/spec/lib/vin_query/query_spec.rb
+++ b/spec/lib/vin_query/query_spec.rb
@@ -100,6 +100,7 @@ describe VinQuery::Query do
       end
 
       it 'fetches xml and response is valid' do
+        expect(client.response_xml).to eq xml_multi
         expect(client.valid?).to be true
       end
 
@@ -115,6 +116,7 @@ describe VinQuery::Query do
       end
 
       it 'fetches xml and response is not valid' do
+        expect(client.response_xml).to eq xml_error
         expect(client.valid?).to be false
       end
 
@@ -124,10 +126,13 @@ describe VinQuery::Query do
     end
 
     context '404 response' do
-      before { allow(client).to receive(:fetch).and_return('<html>404</html>') }
+      let(:response_404) { '<html>404</html>' }
+
+      before { allow(client).to receive(:fetch).and_return(response_404) }
 
       it 'fetches xml and response cannot be validated' do
         expect{ client.get }.to raise_error VinQuery::ValidationError
+        expect(client.response_xml).to eq response_404
       end
     end
   end


### PR DESCRIPTION
I needed access to the response XML so that I can diagnose issues in production. This may come in handy for other.

Also, I added some constants for the `report_type`, for better readability.